### PR TITLE
gitolite.managed: Manage gitolite via SaltStack

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,3 +25,9 @@ Available states
 ------------
 
 Installs the gitolite environment for the users specified in the pillar.
+
+``gitolite.managed``
+------------
+
+Creates an admin user for each specified user and uses it to manage gitolite.
+You may add your very own (Jinja-enabled) gitolite.conf and add loads of pubkeys.

--- a/gitolite/defaults.jinja
+++ b/gitolite/defaults.jinja
@@ -4,7 +4,8 @@
     'home': '/home',
     'repository_url': 'https://github.com/sitaramc/gitolite.git',
     'revision': 'v3.6.1',
-    'ssh_pubkey': 'Undefined'
+    'ssh_pubkey': 'Undefined',
+    'ssh_pubkey_source': 'salt://ssh_keys',
   }
 %}
 

--- a/gitolite/defaults.jinja
+++ b/gitolite/defaults.jinja
@@ -1,11 +1,19 @@
 {% set gitolite = {
-    'users': ['git'],
+    'users': [{'username': 'git'}],
     'shell': '/bin/bash',
     'home': '/home',
     'repository_url': 'https://github.com/sitaramc/gitolite.git',
     'revision': 'v3.6.1',
-    'ssh_pubkey': Undefined
+    'ssh_pubkey': 'Undefined'
   }
 %}
 
 {% do gitolite.update(salt['pillar.get']('gitolite')) %}
+
+{% macro get_shell(user, gitolite) -%}
+{{ user.shell if user.shell is defined else gitolite.shell }}
+{%- endmacro %}
+
+{% macro get_home(user, gitolite) -%}
+{{ user.home if user.home is defined else gitolite.home + '/' + user.username }}
+{%- endmacro %}

--- a/gitolite/files/gitolite.conf.jinja
+++ b/gitolite/files/gitolite.conf.jinja
@@ -1,0 +1,12 @@
+# This is just a simple example.
+# It does not make sense to reimplement the gitolite.conf
+# syntax in a pillar.
+#
+# Just override this file by creating your own in
+# /srv/salt/states/gitolite/files/gitolite.conf.jinja.
+
+repo gitolite-admin
+    RW+     =   gitolite-admin
+
+repo testing
+    RW+     =   @all

--- a/gitolite/init.sls
+++ b/gitolite/init.sls
@@ -1,4 +1,6 @@
 {% from "gitolite/defaults.jinja" import gitolite with context %}
+{% from "gitolite/defaults.jinja" import get_home %}
+{% from "gitolite/defaults.jinja" import get_shell %}
 
 include:
   - git
@@ -11,9 +13,9 @@ perl-Data-Dumper:
 
 {% for user in gitolite.users %}
 
-# variables
-{% set shell = user.shell if user.shell is defined else gitolite.shell %}
-{% set home = user.home if user.home is defined else gitolite.home + '/' + user.username %}
+{# variables #}
+{% set shell = get_shell(user, gitolite) %}
+{% set home = get_home(user, gitolite) %}
 {% set ssh_pubkey = user.ssh_pubkey if user.ssh_pubkey is defined else gitolite.ssh_pubkey %}
 
 {{ user.username }}_user:

--- a/gitolite/init.sls
+++ b/gitolite/init.sls
@@ -55,6 +55,7 @@ install_gitolite_{{ user.username }}:
     - name: {{ home }}/gitolite/install -ln {{ home }}/bin
     - user: {{ user.username }}
     - cwd: {{ home }}
+    - creates: {{ home }}/bin/gitolite
     - require:
       - git: {{ home }}/gitolite
       - file: {{ home }}/bin
@@ -66,6 +67,8 @@ setup_gitolite_{{ user.username }}:
     - cwd: {{ home }}
     - env:
       - HOME: {{ home }}
+    - onchanges:
+      - file: {{ home }}/gitolite-admin.pub
     - require:
       - cmd: install_gitolite_{{ user.username }}
       - file: {{ home }}/gitolite-admin.pub

--- a/gitolite/managed.sls
+++ b/gitolite/managed.sls
@@ -1,0 +1,45 @@
+{% from "gitolite/defaults.jinja" import gitolite with context %}
+{% from "gitolite/defaults.jinja" import get_home %}
+{% from "gitolite/defaults.jinja" import get_shell %}
+
+include:
+  - gitolite
+
+{% for user in gitolite.users %}
+{% set home = get_home(user, gitolite) %}
+{% set shell = get_shell(user, gitolite) %}
+{% set admin_home = "{}-admin".format(home) %}
+{% set admin_username = "{}-admin".format(user.username) %}
+
+{{ user.username }}_admin_user:
+  user.present:
+    - name: {{ admin_username }}
+    - shell: {{ shell }}
+    - home: {{ admin_home }}
+
+{{ admin_home }}/.ssh:
+  file.directory:
+    - user: {{ admin_username }}
+    - mode: 700
+    - require:
+      - user: {{ user.username }}_admin_user
+
+generate_{{ user.username }}_admin_key:
+  cmd.run:  
+    - name: "ssh-keygen -t rsa -N '' -f {{ admin_home }}/.ssh/id_rsa"
+    - user: {{ admin_username }}
+    - creates: {{ admin_home }}/.ssh/id_rsa.pub
+    - require:
+      - file: {{ admin_home }}/.ssh
+      - user: {{ user.username }}_admin_user
+    - require_in:
+      - file: {{ home }}/gitolite-admin.pub
+
+extend:
+  {{ home }}/gitolite-admin.pub:
+    file.copy:
+      - force: True
+      - source: {{ admin_home }}/.ssh/id_rsa.pub
+      - onchanges:
+        - cmd: generate_{{ user.username }}_admin_key
+{% endfor %}

--- a/gitolite/managed.sls
+++ b/gitolite/managed.sls
@@ -84,7 +84,7 @@ set_email_admin_repo_{{ user.username }}:
 {% for key in user.get("ssh_pubkeys", []) %}
 client_pubkey_{{key}}_admin_repo_{{ user.username }}:
   file.managed:
-    - name: {{ admin_home }}/gitolite-admin/keydir/{{ key }}.pub
+    - name: {{ admin_home }}/gitolite-admin/keydir/{{ key|replace("@", "_") }}.pub
     - user: {{ admin_username }}
     - group: {{ admin_username }}
     - source: {{ ssh_pubkey_source }}/{{ key }}.pub

--- a/gitolite/managed.sls
+++ b/gitolite/managed.sls
@@ -5,7 +5,7 @@
 include:
   - gitolite
 
-{% for user in gitolite.users %}
+{% for user in gitolite.users if user.get("managed", False) %}
 {% set home = get_home(user, gitolite) %}
 {% set shell = get_shell(user, gitolite) %}
 {% set admin_home = "{}-admin".format(home) %}

--- a/gitolite/managed.sls
+++ b/gitolite/managed.sls
@@ -42,4 +42,14 @@ extend:
       - source: {{ admin_home }}/.ssh/id_rsa.pub
       - onchanges:
         - cmd: generate_{{ user.username }}_admin_key
+
+clone_admin_repo_{{ user.username }}:
+  git.latest:
+    - name: git@localhost:gitolite-admin.git
+    - rev: master
+    - user: {{ admin_username }}
+    - target: {{ admin_home }}/gitolite-admin
+    - require:
+      - cmd: setup_gitolite_{{ user.username }}
+
 {% endfor %}

--- a/pillar.example
+++ b/pillar.example
@@ -4,8 +4,14 @@ gitolite:
   repository_url: https://github.com/sitaramc/gitolite.git
   revision: v3.6.1
   ssh_pubkey: ssh-rsa here_goes_your_public_ssh_key== admin@example.com # default admin key if user's ssh_pubkey is not defined
+  ssh_pubkey_source': salt://ssh_keys  # default SSH pubkey source
   users:
     - username: git
       ssh_pubkey: ssh-rsa here_goes_your_public_ssh_key== git@example.com
       shell: /bin/zsh
       managed: True  # Manage via Salt; Include gitolite.managed!
+      gitolite_conf_source: salt://gitolite/files/my_gitolite.conf.jinja
+      ssh_pubkey_source: salt://ssh_keys  # May be ommitted
+      ssh_pubkeys:
+        - alice
+        - bob

--- a/pillar.example
+++ b/pillar.example
@@ -8,3 +8,4 @@ gitolite:
     - username: git
       ssh_pubkey: ssh-rsa here_goes_your_public_ssh_key== git@example.com
       shell: /bin/zsh
+      managed: True  # Manage via Salt; Include gitolite.managed!


### PR DESCRIPTION
Creates an admin user for each specified user and uses it to manage gitolite. You may add your very own (Jinja-enabled) gitolite.conf and add loads of pubkeys.

-  manage SSH keys (per git-user)
-  manage `gitolite.conf` (per git-user)

```yaml
gitolite:
  shell: /bin/bash
  home: /home
  repository_url: https://github.com/sitaramc/gitolite.git
  revision: v3.6.1
  ssh_pubkey: ssh-rsa here_goes_your_public_ssh_key== admin@example.com # default admin key if user's ssh_pubkey is not defined
  ssh_pubkey_source': salt://ssh_keys  # default SSH pubkey source
  users:
    - username: git
      ssh_pubkey: ssh-rsa here_goes_your_public_ssh_key== git@example.com
      shell: /bin/zsh
      managed: True  # Manage via Salt; Include gitolite.managed!
      gitolite_conf_source: salt://gitolite/files/my_gitolite.conf.jinja
      ssh_pubkey_source: salt://ssh_keys  # May be ommitted
      ssh_pubkeys:
        - alice
        - bob
```