### PR TITLE
Opt-in to set GIT_CONFIG_KEYS

### DIFF
--- a/gitolite/init.sls
+++ b/gitolite/init.sls
@@ -86,6 +86,18 @@ gitolite_set_umask_for_{{ user.username }}:
       - cmd: setup_gitolite_{{ user.username }}
 {% endif %}
 
+{% if user.get('git_config_keys', False) %}
+gitolite_set_git_config_keys_for_{{ user.username }}:
+  file.replace:
+    - name: {{ home }}/.gitolite.rc
+    - pattern: "GIT_CONFIG_KEYS.*=>.*,"
+    - repl: "GIT_CONFIG_KEYS => '{{ user.git_config_keys }}',"
+    - require:
+      - cmd: install_gitolite_{{ user.username }}
+    - require_in:
+      - cmd: setup_gitolite_{{ user.username }}
+{% endif %}
+
 setup_gitolite_{{ user.username }}:
   cmd.run:
     - name: {{ home }}/gitolite/src/gitolite setup -pk {{ home }}/gitolite-admin.pub

--- a/pillar.example
+++ b/pillar.example
@@ -28,3 +28,5 @@ gitolite:
       ssh_pubkeys:
         - alice
         - bob
+      # Set GIT_CONFIG_KEYS to enable 'config key=value' in the repo config file
+      git_config_keys: '.*'


### PR DESCRIPTION
Tested on Ubuntu 16.04.

Prevents this error when pushing `config` to the admin repo:

```
remote: FATAL: git config 'fetch' not allowed
remote: check GIT_CONFIG_KEYS in the rc file
```

See also: https://stackoverflow.com/questions/13311258/gitweb-and-gitolite-cannot-add-new-repo#13311409