### PR TITLE
feature(managed): allow to remove SSH pubkeys

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -28,5 +28,7 @@ gitolite:
       ssh_pubkeys:
         - alice
         - bob
+        - name: mallory
+          remove: True
       # Set GIT_CONFIG_KEYS to enable 'config key=value' in the repo config file
       git_config_keys: '.*'


### PR DESCRIPTION
Tested on Ubuntu 18.04.

Allows to remove obsolete SSH public keys via `gitolite.managed`.